### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,8 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    <script>
+        window["gitbook-plugin-github-buttons"] = {{ config.pluginsConfig['github-buttons']|dump|safe }};
+    </script>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -3,16 +3,7 @@ module.exports = {
         assets: './lib',
         js: [
             'plugin.js'
-        ],
-        html: {
-            "head:end": function () {
-                // window["gitbook-plugin-github-buttons"]
-                var configs = JSON.stringify(this.options.pluginsConfig["github-buttons"]);
-                return '<script>' +
-                    'window["gitbook-plugin-github-buttons"] = ' + configs + ';'
-                    + '</script>';
-            }
-        }
+        ]
     }
 
 };


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

You will have to upgrade the engine in your `package.json`:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
