### PR TITLE
Fix missing '_layout' folder issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "description": "Gitbook plugin provide GitHub Button.",
   "main": "index.js",
   "files": [
+    "_layouts",
     "index.js",
     "lib",
     "src"


### PR DESCRIPTION
Commit e316ee8 add GitBook3 templating, however, without enable it in
'package.json' `files` section, the `_layout` folder will never be
published. Which made the improvement had no effect. This commit fix the
issue.

Signed-off-by: Tao Wang <twang2218@gmail.com>